### PR TITLE
[fix] More robust exclusion for per-WordPress probes

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
+++ b/ansible/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
@@ -3,7 +3,7 @@ groups:
   - name: Monitoring targets
     rules:
     - alert: Prometheus monitoring target is unavailable
-      expr: up{probe!~".*ressenti.*",job!="wordpresses@epfl"} < 1
+      expr: up{probe!~".*ressenti.*",wp_env!~".+",url!~".+"} < 1
       for: 15m
       labels:
         severity: page


### PR DESCRIPTION
Something apparently changed after restarting the Prometheus inside OpenShift (incompatible behavior after version upgrade?)
- Exclude everything that has a `url` or a `wp_env`
- Forget about matching by `job` (that's the part that stopped working for some reason)
