### PR TITLE
[fix] Negative values in “Restic backup duration”

### DIFF
--- a/roles/grafana/files/provisioning/dashboards/WordPress-general.json
+++ b/roles/grafana/files/provisioning/dashboards/WordPress-general.json
@@ -407,6 +407,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -861,6 +862,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1118,6 +1120,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1335,6 +1338,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1511,7 +1515,8 @@
             "type": "prometheus",
             "uid": "PA7DAED22D5425F49"
           },
-          "expr": "sort_desc(sum(restic_success{url=~\"$wp_site\",wp_env=~\"$wp_env\"}) by (url) - sum(restic_start{url=~\"$wp_site\",wp_env=~\"$wp_env\"}) by (url))",
+          "editorMode": "code",
+          "expr": "sort_desc(restic_success{url=~\"$wp_site\",wp_env=~\"$wp_env\"} - restic_start{url=~\"$wp_site\",wp_env=~\"$wp_env\"} > 0)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{ url }}",
@@ -1557,6 +1562,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1755,6 +1761,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1914,6 +1921,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -1996,6 +2004,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -2079,6 +2088,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -2216,6 +2226,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -2365,6 +2376,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
@@ -2538,6 +2550,6 @@
   "timezone": "",
   "title": "WP Main",
   "uid": "WordPressM",
-  "version": 1,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1629585/199543827-898ba196-3951-441d-bf5f-c7bf11408a92.png)

After: 
![image](https://user-images.githubusercontent.com/1629585/199543881-53c10e07-7c07-40da-a148-f6ba101af6c3.png)

Also, save to version 5 of the JSON format (not sure how I went down to version 1 in [previous PR](https://github.com/epfl-si/external-noc/pull/50); I *think* I was using the per-graph JSON, whereas this time I used the JSON export at whole-dashboard level)