### PR TITLE
[fix] Inside alerts

### DIFF
--- a/roles/prometheus/templates/prometheus/rules/alert-instance-not-200.yml
+++ b/roles/prometheus/templates/prometheus/rules/alert-instance-not-200.yml
@@ -3,7 +3,20 @@ groups:
   - name: Site not 200
     rules:
     - alert: Site status code is not 200
-      expr: probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich"} != 200 and probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich"} != 0
+      expr: probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich",wp_env!="inside"} != 200 and probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich",wp_env!="inside"} != 0
+      for: 2m
+      labels:
+        severity: page
+        sendto: telegram
+        app: wordpress
+      annotations:
+        summary: '{{ $labels.instance }} HTTP status is {{ $value }}!'
+        description: '{{ $labels.instance }} of job {{ $labels.job }} has HTTP status == {{ $value }} for more than 2 minutes (on env: {{ $labels.wp_env }}).'
+
+  - name: Inside site not 200 or 301
+    rules:
+    - alert: Inside site status code is neither 200 nor 301
+      expr: probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich",wp_env="inside"} != 200 and probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich",wp_env="inside"} != 301 and probe_http_status_code{job="wordpresses@epfl",origin="noc-zurich",wp_env="inside"} != 0
       for: 2m
       labels:
         severity: page


### PR DESCRIPTION
For whatever reason (perhaps Tequila was accessible from ressenti-zrh?), we got away for a long time with treating inside Wordpresses as though they would serve 200's, which they won't.

Before:
<img width="1362" alt="image" src="https://github.com/epfl-si/external-noc/assets/1629585/ef1e5c67-f411-46c5-8f90-24a2e5b54941">

After:
<img width="787" alt="image" src="https://github.com/epfl-si/external-noc/assets/1629585/22f92f65-5a09-43fd-9656-8153c4fc6ce1">
