### PR TITLE
[feature] uptime kuma

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -75,6 +75,12 @@
         - noc
         - pushgateway
 
+    - name: kuma
+      role: roles/kuma
+      tags:
+        - noc
+        - kuma
+
     - name: mgmt
       role: roles/mgmt
       tags: mgmt

--- a/roles/kuma/README-kuma.md
+++ b/roles/kuma/README-kuma.md
@@ -1,0 +1,20 @@
+# Kuma
+
+## About
+
+Uptime Kuma is an easy-to-use self-hosted monitoring tool, similar to uptime 
+robot but free and open source.
+
+## Install notes
+
+- https://github.com/louislam/uptime-kuma
+- https://hub.docker.com/r/louislam/uptime-kuma
+
+```sh
+docker run -d \
+  --restart=always \
+  -p 3001:3001 \
+  -v uptime-kuma:/app/data \
+  --name uptime-kuma \
+  louislam/uptime-kuma:1
+```

--- a/roles/kuma/tasks/main.yml
+++ b/roles/kuma/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Create the Kuma volume
+  file:
+    path: "{{ data_path }}/kuma/data"
+    state: directory
+
+- name: Run Kuma
+  docker_container:
+    name: "{{ kuma_container_name }}"
+    image: "{{ kuma_image_qualified }}"
+    detach: yes
+    restart_policy: unless-stopped
+    recreate: >-
+      {{
+        (kuma_config_files is defined and kuma_config_files is changed)
+        or
+        (kuma_templates is defined and kuma_templates is changed)
+      }}
+    network_mode: "{{ backend_network_name }}"
+    volumes:
+      - "{{ data_path }}/kuma/data:/app/data"
+    log_driver: json-file
+    log_options:
+      max-size: 50m
+      max-file: "3"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.kuma.rule: "Host(`kuma.noc{{ dns_suffix }}.{{ frontend.domain }}`)"
+      traefik.http.routers.kuma.entrypoints: "websecure"
+      traefik.http.routers.kuma.tls.certresolver: "letsencrypt"
+      traefik.docker.network: "{{ backend_network_name }}"

--- a/roles/kuma/vars/main.yml
+++ b/roles/kuma/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# vars for Kuma
+kuma_port: 3001
+kuma_container_name: "kuma"
+kuma_image: "louislam/uptime-kuma"
+kuma_version: "1"
+kuma_image_qualified: "{{ kuma_image }}:{{ kuma_version }}"


### PR DESCRIPTION
Please note that Kuma is a very simple tools that can be convenient for a small team but it's not built neither for multi-tenancy[1] nor to be managed by configuration as code[2].

For now, there are no way to configure a set of monitoring target while deploying it, and for now there is no backup (but the volume).

[1]: https://github.com/louislam/uptime-kuma/issues/128
[2]: https://www.reddit.com/r/UptimeKuma/comments/1aluk0j/monitors_configuration_as_code/