### PR TITLE
[feature] Alert when unable to federate from Prometheus targets for 15m

### DIFF
--- a/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
+++ b/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
@@ -8,7 +8,6 @@ groups:
       labels:
         severity: page
         sendto: telegram
-        app: wordpress
       annotations:
         summary: 'Prometheus target "{{$labels.job}}" is unreachable (instance = {{$labels.instance}}, probe = "{{$labels.probe}}")'
 {%endraw%}

--- a/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
+++ b/roles/prometheus/templates/prometheus/rules/alert-prometheus-targets.yml
@@ -1,0 +1,14 @@
+{%raw%}
+groups:
+  - name: Monitoring targets
+    rules:
+    - alert: Prometheus monitoring target is unavailable
+      expr: up{probe!~".*ressenti.*",job!="wordpresses@epfl"} < 1
+      for: 15m
+      labels:
+        severity: page
+        sendto: telegram
+        app: wordpress
+      annotations:
+        summary: 'Prometheus target "{{$labels.job}}" is unreachable (instance = {{$labels.instance}}, probe = "{{$labels.probe}}")'
+{%endraw%}


### PR DESCRIPTION
This rule was already present on noc-test (`/srv/noc/prometheus/rules/alert-prometheus-targets.yml`), and appears to have been working reasonably well during https://go.epfl.ch/INC0653316 (as in, it was the test alert that clued us in, and it stopped firing as soon as the A10 issue got resolved.)