### PR TITLE
[fix] `ZeebeQuorumNotMakingProgress` false positive

### DIFF
--- a/roles/prometheus/templates/prometheus/rules/alert-phdassess-zeebe-quorum.yml
+++ b/roles/prometheus/templates/prometheus/rules/alert-phdassess-zeebe-quorum.yml
@@ -138,7 +138,9 @@ groups:
     ###############################################################
     - alert: ZeebeQuorumNotMakingProgress
       expr: |-
+        max(
         increase(atomix_partition_raft_commit_index{app_instance="prod",persistence!="nfs"}[5m])
+        )
         < 100
       for: 5m
       labels:


### PR DESCRIPTION
This happened today because the VM Zeebe was having some ssh tunneling trouble.