### PR TITLE
[fix] Set postfix based-image (latest-alpine)

### DIFF
--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Postfix black hole
   docker_container:
     name: postfix-blackhole
-    image: boky/postfix
+    image: boky/postfix:latest-alpine
     restart: "{{ _postfix_config is changed }}"
     ports:
       - '25:25'


### PR DESCRIPTION
The config is broken since the the default image is based from Debian, since v4.0.0