### PR TITLE
[fix] Alertmanager external-url

### DIFF
--- a/roles/alertmanager/tasks/main.yml
+++ b/roles/alertmanager/tasks/main.yml
@@ -22,7 +22,7 @@
         --storage.path=/tmp 
         --log.level=debug
       {% endif %}
-      --web.external-url=https://am{{ dns_suffix }}.{{ frontend.domain }}
+      --web.external-url=https://am.noc{{ dns_suffix }}.{{ frontend.domain }}
     restart_policy: unless-stopped
     network_mode: "{{ backend_network_name }}"
     mounts: "{{ mounts[runenv] }}"


### PR DESCRIPTION
The configured external_url appears in the email notifications sent by Alertmanager.

https://am(-test).fsd.team → https://am.noc(-test).fsd.team