### PR TITLE
Bump ansible version to the latest found on pip, to be compatible with Python 3.13

### DIFF
--- a/nocsible
+++ b/nocsible
@@ -41,7 +41,7 @@ platform_check () {
         curl https://raw.githubusercontent.com/epfl-si/ansible.suitcase/master/install.sh | \
             SUITCASE_DIR=$PWD/ansible-deps-cache \
             SUITCASE_PIP_EXTRA="bcrypt passlib" \
-            SUITCASE_ANSIBLE_VERSION=3.4.0 \
+            SUITCASE_ANSIBLE_VERSION=11.5.0 \
             SUITCASE_ANSIBLE_REQUIREMENTS=requirements.yml \
             bash -x
     fi


### PR DESCRIPTION
On my new and shiny Ubuntu 25.04, the OS provide Python 3.13. Installing the suitcase with ansible 3.4.0 create an error with the Python2 compatibility layer: `No module named 'ansible.module_utils.six.moves' `. 