### PR TITLE
Unstuck the configurator script

### DIFF
--- a/roles/prometheus/templates/prometheus-site-service-discovery.py
+++ b/roles/prometheus/templates/prometheus-site-service-discovery.py
@@ -1,6 +1,6 @@
 """Automatically compute targets for the production WordPress Prometheus.
 
-Every 60 seconds, enumerate Web sites in wp-veritas and produce a number
+Every 300 seconds, enumerate Web sites in wp-veritas and produce a number
 of dynamic targets for it.
 
 See https://github.com/epfl-si/wp-ops/blob/master/ansible/roles/wordpress-openshift-namespace/templates/prometheus-menu-service-discovery.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import json
 import logging
 import os
+import socket
 import time
 import traceback
 import urllib.request
@@ -32,7 +33,7 @@ class DynamicConfig:
             flush=True)
 
     def _get_json(self):
-        res = urllib.request.urlopen(self.url)
+        res = urllib.request.urlopen(self.url, timeout=30)
         return ''.join(res.read().decode("utf-8"))
 
     @property
@@ -65,4 +66,8 @@ while True:
         dc.write_targets()
     except:  # noqa
         logging.error(traceback.format_exc())
+    except socket.timeout:
+        logging.error("Request timed out after 30s.")
+    except Exception:  # noqa
+        logging.error("Error during target update: %s", traceback.format_exc())
     time.sleep(dc.frequency)

--- a/roles/prometheus/templates/prometheus-site-service-discovery.py
+++ b/roles/prometheus/templates/prometheus-site-service-discovery.py
@@ -15,6 +15,12 @@ import time
 import traceback
 import urllib.request
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S"
+)
+
 class DynamicConfig:
 
     targetPath = "/srv/dynamic/targets.json"
@@ -26,11 +32,10 @@ class DynamicConfig:
         else:
             self.targetPath = DynamicConfig.targetPath
         self.frequency = frequency
-        print(f"{datetime.now().isoformat()} Configurator started !"
-              f"\n\t - url: {self.url}"
-              f"\n\t - dynamic file: {self.targetPath}"
-              f"\n\t - frequency: {self.frequency}s",
-            flush=True)
+        logging.info(
+            "Configurator started! url=%s dynamic_file=%s frequency=%ss",
+            self.url, self.targetPath, self.frequency
+        )
 
     def _get_json(self):
         res = urllib.request.urlopen(self.url, timeout=30)
@@ -63,9 +68,10 @@ class DynamicConfig:
 while True:
     dc = DynamicConfig()
     try:
+        logging.info("Updating targets...")
         dc.write_targets()
-    except:  # noqa
-        logging.error(traceback.format_exc())
+        logging.info("Targets updated successfully (%d targets written to %s). Sleeping %ss.",
+                     len(dc.targets), dc.targetPath, dc.frequency)
     except socket.timeout:
         logging.error("Request timed out after 30s.")
     except Exception:  # noqa


### PR DESCRIPTION
Should fix #77 

1. Add a timeout to urlopen (e.g., 30 seconds) so a stuck request fails and the loop continues.
2. Add more logging info.
3. Align the doc about the default frequency, 300.

With the help of Opencode.